### PR TITLE
Optimize float point debug info

### DIFF
--- a/library/Graph.cpp
+++ b/library/Graph.cpp
@@ -302,6 +302,13 @@ void Graph::generateCCode(std::ostream &os, uint32_t seed) {
     os << op->getNameWithType() << "();\n";
   }
 
+  // return 1 if any there is any failure in the operator
+  os << "int ret = 1; // 1 = success\n";
+  for (auto id : ordering) {
+    auto op = operatorLUT[id];
+    os << "ret &= golden_" << op->getNameWithType() << "();\n";
+  }
+
   // verify
   for (auto id : ordering) {
     auto op = operatorLUT[id];
@@ -313,12 +320,6 @@ void Graph::generateCCode(std::ostream &os, uint32_t seed) {
        << "() ? \"pass\" : \"fail\");\n";
   }
 
-  // return 1 if any there is any failure in the operator
-  os << "int ret = 1; // 1 = success\n";
-  for (auto id : ordering) {
-    auto op = operatorLUT[id];
-    os << "ret &= golden_" << op->getNameWithType() << "();\n";
-  }
   os << "if (!ret) return 1;\n";
 
   // end of main function

--- a/library/Operator.cpp
+++ b/library/Operator.cpp
@@ -1903,9 +1903,9 @@ void emitOneDVerificationCode<OneDFloat64Val>(std::ostream &os,
   os << "converter2.f64 = " << output->id << "[i];\n";
   os << "printf(\"rif:converter.f64 = \%f, intrinsic:converter2.f64 = \%f\\n\", "
         "(double)converter.f64, (double)converter2.f64);\n";
-  os << "printf(\"rif:converter.u64 = \%u, intrinsic:converter2.u64 = \%u\\n\", "
+  os << "printf(\"rif:converter.u64 = \%lu, intrinsic:converter2.u64 = \%lu\\n\", "
         "converter.u64, converter2.u64);\n";
-  os << "printf(\"rif:converter.u64 = \%x, intrinsic:converter2.u64 = \%x\\n\", "
+  os << "printf(\"rif:converter.u64 = \%lx, intrinsic:converter2.u64 = \%lx\\n\", "
         "converter.u64, converter2.u64);\n";
   os << "if(converter.f64 != converter2.f64 && !(isNaNF64UI(converter.u64) && "
         "isNaNF64UI(converter2.u64))) {\n";


### PR DESCRIPTION
Script for report deals with result by read "pass" or "fail" at tail, so reorder.
Fix printf() format for float64.